### PR TITLE
Prevent crash

### DIFF
--- a/Kern-A-Lytics.glyphsFilter/Contents/Resources/kernGraph.py
+++ b/Kern-A-Lytics.glyphsFilter/Contents/Resources/kernGraph.py
@@ -455,10 +455,11 @@ class FlexibleWindow(object):
 
             for f_index, f in enumerate(self.fonts):
                 repr_pair = kerningHelper.get_repr_pair(f, self.pair)
-                repr_glyphs = [f[g_name] for g_name in repr_pair]
-                kern_value = f.kerning.get(self.pair, 0)
-                pair_obj = getattr(self.w.pairPreview, 'pair_{}'.format(f_index))
-                pair_obj.setGlyphData_kerning(repr_glyphs, kern_value)
+                if repr_pair: # can be None
+                    repr_glyphs = [f[g_name] for g_name in repr_pair]
+                    kern_value = f.kerning.get(self.pair, 0)
+                    pair_obj = getattr(self.w.pairPreview, 'pair_{}'.format(f_index))
+                    pair_obj.setGlyphData_kerning(repr_glyphs, kern_value)
     @property
     def checked(self):
         checked = []


### PR DESCRIPTION
The Plugin Kern-A-Lytics.glyphsFilter has caused a crash in Glyphs 2.5.2-1167.

Details:

```
Traceback (most recent call last):

 File "~/Library/Application Support/Glyphs/Scripts/vanilla/vanillaList.py", line 53, in observeValueForKeyPath_ofObject_change_context_
   self._targetMethod()

 File "~/Library/Application Support/Glyphs/Scripts/vanilla/vanillaList.py", line 791, in _selection
   self._selectionCallback(self)

 File "~/Library/Application Support/Glyphs/Repositories/Kern-A-Lytics/Kern-A-Lytics.glyphsFilter/Contents/Resources/kernGraph.py", line 458, in list_callback
   repr_glyphs = [f[g_name] for g_name in repr_pair]

TypeError: 'NoneType' object is not iterable
```